### PR TITLE
feat: upgrade guava to version 30.0-jre or later to avoid attacker wi…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
         <commons_cli_version>1.4</commons_cli_version>
         <slf4j_version>1.7.25</slf4j_version>
         <logback_version>1.2.2</logback_version>
-        <guava_version>29.0-jre</guava_version>
+        <guava_version>[30.0-jre,)</guava_version>
         <jedis_version>2.9.0</jedis_version>
         <redisson_version>3.11.5</redisson_version>
         <fastjson_version>1.2.47</fastjson_version>
@@ -475,6 +475,7 @@
                                 <exclude>**/*.txt</exclude>
                                 <exclude>**/*.xml</exclude>
                                 <exclude>**/*.out</exclude>
+                                <exclude>.github/</exclude>
                             </excludes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
…th access to the machine to potentially access data in a temporary directory created by the Guava com.google.common.io.Files.createTempDir().